### PR TITLE
Add resend email verification feature with rate limiting

### DIFF
--- a/apps/users/models/user.py
+++ b/apps/users/models/user.py
@@ -64,6 +64,9 @@ class User(BaseModel, AbstractUser, PermissionsMixin):
         send_email_otp_task.delay(self.pk)
         return None
 
+    def clear_email_verification_otps(self) -> None:
+        self.otp_codes.delete()
+
     class Meta:
         db_table = "users"
         verbose_name = _("User")

--- a/apps/users/routes/api.py
+++ b/apps/users/routes/api.py
@@ -1,10 +1,11 @@
 from django.urls import re_path
-from apps.users.views.auth_view import UserRegistrationView, LoginView, PasswordResetRequestView, PasswordResetConfirmationView, LogoutView, EmailVerificationView
+from apps.users.views.auth_view import ResendEmailVerificationView, UserRegistrationView, LoginView, PasswordResetRequestView, PasswordResetConfirmationView, LogoutView, EmailVerificationView
 from apps.users.views.user_views import UserDetails, UpdateUserProfile, OrganizersListView
 
 urlpatterns = [
     re_path(r'^auth/register/$', UserRegistrationView.as_view(), name='register'),
     re_path(r'^auth/verify-email/$', EmailVerificationView.as_view(), name='verify-email'),
+    re_path(r'^auth/resend-verification/$', ResendEmailVerificationView.as_view(), name='resend-verification'),
     re_path(r'^auth/login/$', LoginView.as_view(), name='login'),
     re_path(r'^auth/logout/$', LogoutView.as_view(), name='logout'),
     re_path(r'^auth/password/reset/$', PasswordResetRequestView.as_view(), name='password-reset'),

--- a/apps/users/serializers/__init__.py
+++ b/apps/users/serializers/__init__.py
@@ -1,2 +1,2 @@
-from apps.users.serializers.auth_serializers import UserRegistrationSerializer, LoginSerializer, LoginResponseSerializer, PassWordResetRequestSerializer, PasswordResetConfirmationSerializer, EmailVerificationSerializer
+from apps.users.serializers.auth_serializers import UserRegistrationSerializer, LoginSerializer, LoginResponseSerializer, PassWordResetRequestSerializer, PasswordResetConfirmationSerializer, EmailVerificationSerializer, ResendEmailVerificationSerializer
 from apps.users.serializers.general_serializers import SuccessResponseSerializer, ErrorResponseSerializer, UserSerializer, OrganizerSerializer

--- a/apps/users/serializers/auth_serializers.py
+++ b/apps/users/serializers/auth_serializers.py
@@ -110,3 +110,6 @@ class EmailVerificationSerializer(serializers.Serializer):
         min_length=6,
         help_text=_('6-digit OTP code sent to your email')
     )
+
+class ResendEmailVerificationSerializer(serializers.Serializer):
+    email = serializers.EmailField()

--- a/apps/users/views/auth_view.py
+++ b/apps/users/views/auth_view.py
@@ -7,6 +7,7 @@ from rest_framework import permissions
 from rest_framework import status
 from rest_framework.parsers import JSONParser
 from rest_framework.views import APIView
+from rest_framework.throttling import AnonRateThrottle
 
 from apps.users.helpers.auth import generate_tokens, get_serializer
 from apps.users.models import OtpCode
@@ -15,7 +16,7 @@ from apps.users.serializers import (
     ErrorResponseSerializer, LoginSerializer,
     LoginResponseSerializer, UserSerializer,
     PassWordResetRequestSerializer, PasswordResetConfirmationSerializer,
-    EmailVerificationSerializer
+    EmailVerificationSerializer, ResendEmailVerificationSerializer
 )
 from mixins import APIResponseMixin
 from utils.auth import authenticate_user
@@ -287,5 +288,57 @@ class EmailVerificationView(APIResponseMixin, APIView):
 
         return self.success(
             _("Email verified successfully. Your account is now active."),
+            status_code=status.HTTP_200_OK
+        )
+
+class ResendEmailVerificationView(APIResponseMixin, APIView):
+    serializer_class = ResendEmailVerificationSerializer
+    permission_classes = [permissions.AllowAny]
+    parser_classes = [JSONParser]
+
+    throttle_classes = [AnonRateThrottle]
+    throttle_scope = "resend_verification"
+
+    @extend_schema(
+        operation_id="Resend Email Verification",
+        summary="Resend email verification OTP",
+        request=ResendEmailVerificationSerializer,
+        tags=['Auth'],
+        responses={
+            200: OpenApiResponse(
+                response=SuccessResponseSerializer,
+                description=_("If an account with that email exists, a verification code has been sent")
+            ),
+            400: OpenApiResponse(
+                response=ErrorResponseSerializer,
+                description=_("Bad request")
+            ),
+        },
+    )
+    def post(self, request, *args, **kwargs):
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        email = serializer.validated_data['email']
+
+        user = User.objects.select_for_update().filter(email=email).first()
+        if not user:
+            # To not reveal if email exists
+            return self.success(
+                _("If an account with that email exists, a verification code has been sent"),
+                status_code=status.HTTP_200_OK
+            )
+
+        if user.is_active:
+            return self.error(
+                _("Account is already active"),
+                status_code=status.HTTP_400_BAD_REQUEST
+            )
+
+        user.clear_email_verification_otps()
+        user.send_email_otp()
+
+        return self.success(
+            _("If an account with that email exists, a verification code has been sent"),
             status_code=status.HTTP_200_OK
         )

--- a/website_api/settings/base.py
+++ b/website_api/settings/base.py
@@ -84,7 +84,8 @@ EMAIL_HOST = os.getenv("EMAIL_HOST")
 EMAIL_PORT = os.getenv("EMAIL_PORT")
 EMAIL_HOST_USER = os.getenv("EMAIL_HOST_USER")
 EMAIL_HOST_PASSWORD = os.getenv("EMAIL_HOST_PASSWORD")
-EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", False)
+EMAIL_USE_TLS = os.getenv("EMAIL_USE_TLS", "True").lower() == "true"
+EMAIL_USE_SSL = os.getenv("EMAIL_USE_SSL", "False").lower() == "true"
 DEFAULT_FROM_EMAIL = os.getenv("DEFAULT_FROM_EMAIL")
 
 # Password validation

--- a/website_api/settings/extra.py
+++ b/website_api/settings/extra.py
@@ -19,6 +19,7 @@ REST_FRAMEWORK = {
     "DEFAULT_THROTTLE_RATES": {
         "anon": "100/hour",
         "user": "1000/hour",
+        "resend_verification": "3/hour",
     },
     "DEFAULT_PAGINATION_CLASS": "apps.users.pagination.CustomPagination",
     'DEFAULT_SCHEMA_CLASS': 'drf_spectacular.openapi.AutoSchema',


### PR DESCRIPTION
This pull request introduces a new feature that allows users to request a resend of the email verification OTP, along with related improvements to security and configuration. The main changes include adding a new API endpoint with rate limiting for resending verification emails, updating serializers and models to support this functionality, and improving email settings handling.

**New Email Verification Resend Feature:**

* Added a new API endpoint at `/auth/resend-verification/` handled by `ResendEmailVerificationView`, allowing users to request a resend of the verification OTP. This endpoint uses a dedicated serializer and is rate-limited to prevent abuse. [[1]](diffhunk://#diff-973b200a9cfa0c200cb98d6db65ef9ee37ac15946856d6a29083493919288499L2-R8) [[2]](diffhunk://#diff-4210d15ecec30243eeba06ebd96ded86c06e327ec653732073242a9213a34975R294-R345) [[3]](diffhunk://#diff-4a60df4a94c4b2afe4474d8bde751540d4934881625a8f194443cb4bc04aee91R113-R115) [[4]](diffhunk://#diff-4210d15ecec30243eeba06ebd96ded86c06e327ec653732073242a9213a34975R21) [[5]](diffhunk://#diff-4210d15ecec30243eeba06ebd96ded86c06e327ec653732073242a9213a34975R10) [[6]](diffhunk://#diff-00e75cd6e58c464bd2ff0241ce3632fb609ea9f97e4af358f4a639c574416136R22)

**Model and Serializer Enhancements:**

* Added the `clear_email_verification_otps` method to the `User` model to remove existing OTP codes before sending a new one, ensuring only the latest code is valid.
* Introduced `ResendEmailVerificationSerializer` to validate email input for the new resend endpoint.

**Configuration Improvements:**

* Improved email configuration parsing by ensuring `EMAIL_USE_TLS` and `EMAIL_USE_SSL` are correctly interpreted as boolean values from environment variables.
* Added a new throttle scope (`resend_verification`) with a limit of 3 requests per hour to protect the new endpoint.